### PR TITLE
Fix DayZGame constructor being called

### DIFF
--- a/DayZLife/scripts/4_World/Database/DZLPlayer.c
+++ b/DayZLife/scripts/4_World/Database/DZLPlayer.c
@@ -269,7 +269,7 @@ class DZLPlayer
     }
 	
 	void AddMoneyToPlayer(int moneyCount) {
-        if (DayZGame().IsServer()) {
+        if (GetDayZGame().IsServer()) {
             DZLLogMoneyTransaction(dayZPlayerId, "player", money, money + moneyCount, moneyCount);
 			money += moneyCount;
 		    Save();
@@ -277,7 +277,7 @@ class DZLPlayer
     }
 
 	void AddMoneyToPlayerBank(int moneyCount) {
-        if (DayZGame().IsServer()) {
+        if (GetDayZGame().IsServer()) {
             DZLLogMoneyTransaction(dayZPlayerId, "bank", bank, bank + moneyCount, moneyCount);
 			bank += moneyCount;
 		    Save();


### PR DESCRIPTION
Since the new Versions of Advanced Groups use the DayZGame Constructor when verifying the License, it will close the Server when called again later. Please fix this bug. It might also cause memory leak issues with other Mods