### PR TITLE
Fix for stackable items exploit

### DIFF
--- a/DayZLife/scripts/4_World/Menu/DZLTraderMenu.c
+++ b/DayZLife/scripts/4_World/Menu/DZLTraderMenu.c
@@ -65,6 +65,8 @@ class DZLTraderMenu: DZLBaseMenu
     override void UpdateGUI(string message = "") {
 		super.UpdateGUI(message);
 		
+		
+		
 		array<EntityAI> playerItems = player.GetPlayerItems();
 		credits.SetText(dzlPlayer.GetMoney().ToString());
 		

--- a/DayZLife/scripts/4_World/Menu/DZLTraderMenu.c
+++ b/DayZLife/scripts/4_World/Menu/DZLTraderMenu.c
@@ -65,8 +65,6 @@ class DZLTraderMenu: DZLBaseMenu
     override void UpdateGUI(string message = "") {
 		super.UpdateGUI(message);
 		
-		
-		
 		array<EntityAI> playerItems = player.GetPlayerItems();
 		credits.SetText(dzlPlayer.GetMoney().ToString());
 		
@@ -293,7 +291,14 @@ class DZLTraderMenu: DZLBaseMenu
                 if (sellItem) {
                     CarScript carsScript = CarScript.Cast(sellItem);
                     if (!carsScript) {
-                        sellItems.Insert(sellItem);
+			// Edited by Gramps
+			int z;
+			if (sellItem.ConfigGetBool("canBeSplit") && sellItem.GetType() != "Nail" && sellItem.GetType() != "PurificationTablets" && sellItem.GetType() != "CharcoalTablets" && sellItem.GetType() != "PainkillerTablets" && sellItem.GetType() != "TetracyclineAntibiotics"){
+				for (z = 0; z < sellItem.GetQuantity(); z++){
+					sellItems.Insert(sellItem);
+				}
+			} else	sellItems.Insert(sellItem);
+			// End Gramps' edit
                     } else if (!carsScript.isSold && carsScript.ownerId == player.GetPlayerId()) {
 						bool carIsEmpty = true;
 	                    for (int seat = 0; seat < carsScript.CrewSize(); seat++){
@@ -428,6 +433,11 @@ class DZLTraderMenu: DZLBaseMenu
         targetWidget.SetItem(index, quantity, item, 2);
 
         float itemSum = price.ToInt() * factor;
+		// Added by Gramps
+		if (item.ConfigGetBool("canBeSplit") && item.GetType() != "Nail" && item.GetType() != "PurificationTablets" && item.GetType() != "CharcoalTablets" && item.GetType() != "PainkillerTablets" && item.GetType() != "TetracyclineAntibiotics"){
+			itemSum = itemSum * item.GetQuantity();
+		}
+		// End Gramps' addition
         float itemTax = itemSum / 100 * config.bankConfig.sellTradingTax;
 
         sumInt +=  Math.Round(itemSum);
@@ -533,6 +543,11 @@ class DZLTraderMenu: DZLBaseMenu
    					widgetToChange.GetItemData(x, 0, item);	
 					sellPrice = itemType.CalculateDynamicSellPrice(storage, item);
 					sellPrice = itemType.GetQuantityPrice(sellPrice, item);
+				// Added by Gramps
+				if (item.ConfigGetBool("canBeSplit") && item.GetType() != "Nail" && item.GetType() != "PurificationTablets" && item.GetType() != "CharcoalTablets" && item.GetType() != "PainkillerTablets" && item.GetType() != "TetracyclineAntibiotics"){
+					sellPrice = sellPrice * item.GetQuantity();
+				}
+				// End Gramps' addition
 		            widgetToChange.SetItem(x, sellPrice.ToString(), itemType, 1);
 		            widgetToChange.SetItem(x, itemType.GetStorageString(storage), item, 3);
 		        }

--- a/DayZLifeServer/scripts/4_World/EventListener/DZLTraderListener.c
+++ b/DayZLifeServer/scripts/4_World/EventListener/DZLTraderListener.c
@@ -61,6 +61,9 @@ class DZLTraderListener
                                     float itemPrice = type.CalculateDynamicSellPrice(storage, item);
 									itemPrice = type.GetQuantityPrice(itemPrice, item);
 									float itemTax = itemPrice / 100 * bankConfig.sellTradingTax;
+					// Added by Gramps
+					if (item.ConfigGetBool("canBeSplit") && item.GetType() != "Nail" && item.GetType() != "PurificationTablets" && item.GetType() != "CharcoalTablets" && item.GetType() != "PainkillerTablets" && item.GetType() != "TetracyclineAntibiotics")	itemPrice * item.GetQuantity();
+					// End Gramps' addition
 
                                     sum -=  Math.Round(itemPrice - itemTax);
                                     taxSum += Math.Round(itemTax);
@@ -163,6 +166,12 @@ class DZLTraderListener
 	        if (!item) {
 	            item = player.SpawnEntityOnGroundPos(type.type, player.GetPosition());
 	        }
+		// Added by Gramps
+		if (item && item.ConfigGetBool("canBeSplit")){
+			ItemBase entityAi = ItemBase.Cast(item);
+			if (entityAi && entityAi.GetType() != "Nail" && entityAi.GetType() != "PurificationTablets" && entityAi.GetType() != "CharcoalTablets" && entityAi.GetType() != "PainkillerTablets" && entityAi.GetType() != "TetracyclineAntibiotics")	entityAi.SetQuantity(1);
+		}
+		// End Gramps' addition
 		}
 
 		if (item) {

--- a/DayZLifeServer/scripts/4_World/EventListener/DZLTraderListener.c
+++ b/DayZLifeServer/scripts/4_World/EventListener/DZLTraderListener.c
@@ -60,10 +60,10 @@ class DZLTraderListener
 									
                                     float itemPrice = type.CalculateDynamicSellPrice(storage, item);
 									itemPrice = type.GetQuantityPrice(itemPrice, item);
-									float itemTax = itemPrice / 100 * bankConfig.sellTradingTax;
 					// Added by Gramps
 					if (item.ConfigGetBool("canBeSplit") && item.GetType() != "Nail" && item.GetType() != "PurificationTablets" && item.GetType() != "CharcoalTablets" && item.GetType() != "PainkillerTablets" && item.GetType() != "TetracyclineAntibiotics")	itemPrice * item.GetQuantity();
 					// End Gramps' addition
+									float itemTax = itemPrice / 100 * bankConfig.sellTradingTax;
 
                                     sum -=  Math.Round(itemPrice - itemTax);
                                     taxSum += Math.Round(itemTax);


### PR DESCRIPTION
What these changes do:
- Calculates the correct price of stackable sellable items.
- Sets the quantity of stackable bought items to 1, except for a few exceptions, mostly medications.
- Calculates the correct quantity of stackable items when buying or selling.